### PR TITLE
Skip on floating windows, no longer crash on floating windows

### DIFF
--- a/alternating_layouts.py
+++ b/alternating_layouts.py
@@ -111,7 +111,8 @@ def main():
     for line in process.stdout:
         tree = get_sway_tree()
         focused_node = traverse_sway_tree(tree, get_focused_node)
-        set_layout(focused_node)
+        if (not isinstance(focused_node,bool)): #skip when returned false(for floating windows)
+            set_layout(focused_node)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is a simple hack to just ignore all windows where traverse_sway_tree returns `False`,
No longer crashes on specific ways to use floating windows